### PR TITLE
Feat: read prefixed env variables to get configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
 dependencies = [
  "atomic",
+ "pear",
  "serde",
  "toml",
  "uncased",
@@ -1838,6 +1839,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -2383,6 +2390,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2595,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4334,6 +4377,12 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/apibara/Cargo.toml
+++ b/apibara/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
+edition = "2021"
 name = "apibara"
 version = "0.3.2"
-edition = "2021"
 
 [dependencies]
-async-trait = "0.1.53"
-async-recursion = "1.0.0"
 anyhow = "1.0"
-backoff = { version = "0.4.0", features = ["tokio"] }
+async-recursion = "1.0.0"
+async-trait = "0.1.53"
+backoff = {version = "0.4.0", features = ["tokio"]}
 chrono = "0.4.19"
-ethers = { version = "0.6.2", features = ["ws", "openssl"] }
-figment = { version = "0.10.6", features = ["toml"] }
+ethers = {version = "0.6.2", features = ["ws", "openssl"]}
+figment = {version = "0.10.6", features = ["toml", "env"]}
 futures = "0.3.21"
 hex = "0.4.3"
 itertools = "0.10.3"
-mongodb = { version = "2.2.2", features = ["tokio-runtime"] }
+mongodb = {version = "2.2.2", features = ["tokio-runtime"]}
 once_cell = "1.12"
 prost = "0.10"
 prost-types = "0.10"
 regex = "1.5"
 semver = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "23d1747c4aea084cc3726707edb11007b37e8433" }
-tonic = "0.7"
+serde = {version = "1.0", features = ["derive"]}
+starknet = {git = "https://github.com/xJonathanLEI/starknet-rs", rev = "23d1747c4aea084cc3726707edb11007b37e8433"}
+tokio = {version = "1.18", features = ["full"]}
 tokio-stream = "0.1.8"
-tokio = { version = "1.18", features = ["full"] }
+tonic = "0.7"
 tracing = "0.1.34"
 url = "2.2.2"
 

--- a/apibara/src/configuration.rs
+++ b/apibara/src/configuration.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, path::Path};
 
 use anyhow::Result;
 use figment::{
-    providers::{Format, Serialized, Toml},
+    providers::{Env, Format, Serialized, Toml},
     Figment,
 };
 use serde::{Deserialize, Serialize};
@@ -54,6 +54,7 @@ impl Configuration {
     pub fn from_path(path: &Path) -> Result<Configuration> {
         let config = Figment::from(Serialized::defaults(Configuration::default()))
             .merge(Toml::file(path))
+            .merge(Env::prefixed("APIBARA_"))
             .extract()?;
         Ok(config)
     }


### PR DESCRIPTION
Getting the configuration only from the Toml file is not convenient and does not follow [the 12 factors app best practices](https://12factor.net/config).
Thankfully figments support multiple sources, including env variables.