### PR TITLE
Add heartbeats to stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tracing",
 ]
 
 [[package]]

--- a/core/proto/node.proto
+++ b/core/proto/node.proto
@@ -77,6 +77,7 @@ message StreamMessagesResponse {
   oneof message {
     Invalidate invalidate = 1;
     Data data = 2;
+    Heartbeat heartbeat = 3;
   }
 }
 
@@ -90,20 +91,6 @@ message Data {
   google.protobuf.Any data = 2;
 }
 
-// Information about the node's sync status.
-message SyncStatus {
-  // The latest sequence number of the stream.
-  uint64 latest_sequence = 1;
-  // Sync state.
-  SyncState state = 2;
-}
-
-// Sync state.
-enum SyncState {
-  // Not specified. This value should not be sent down the wire.
-  SYNC_STATE_UNSPECIFIED = 0;
-  // The node can be considered synced, producing live data.
-  SYNC_STATE_SYNCED = 1;
-  // The node is catching up with their source. Data is stale.
-  SYNC_STATE_CATCHING_UP = 2;
+// Sent to clients to check if stream is still connected.
+message Heartbeat {
 }

--- a/examples/starknet-token-transfer/Cargo.toml
+++ b/examples/starknet-token-transfer/Cargo.toml
@@ -15,6 +15,7 @@ prost-types = "0.11.1"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 tonic = "0.8.0"
+tracing = "0.1.36"
 
 [build-dependencies]
 tonic-build = "0.8.0"

--- a/examples/starknet-token-transfer/src/app.rs
+++ b/examples/starknet-token-transfer/src/app.rs
@@ -5,6 +5,7 @@ use apibara_sdk::{
 };
 use apibara_starknet::pb::{self as starknet_pb};
 use prost::{DecodeError, Message};
+use tracing::info;
 
 lazy_static::lazy_static! {
     // pedersen hash of `Transfer`.
@@ -63,6 +64,8 @@ impl Application for SimpleApplication {
         let block_hash = pb::BlockHash {
             hash: block_hash.hash,
         };
+
+        info!(block = %block.block_number, "receive data");
 
         let mut transfers = Vec::default();
 

--- a/node/src/heartbeat.rs
+++ b/node/src/heartbeat.rs
@@ -1,0 +1,116 @@
+//! Add heartbeat to streams.
+
+use std::{
+    fmt,
+    pin::Pin,
+    task::{self, Poll},
+    time::Duration,
+};
+
+use futures::{stream::Fuse, Future, StreamExt};
+use pin_project::pin_project;
+use tokio::time::{Instant, Sleep};
+use tokio_stream::Stream;
+
+pub trait HeartbeatStreamExt: Stream {
+    /// Returns a new stream that contains heartbeat messages.
+    ///
+    /// Heartbeat messages are produced if the original stream
+    /// doesn't produce any message for `interval` time.
+    /// The heartbeat interval is reset every time the stream
+    /// produces a new message.
+    fn heartbeat(self, interval: Duration) -> Heartbeat<Self>
+    where
+        Self: Sized,
+    {
+        Heartbeat::new(self, interval)
+    }
+}
+
+impl<St: ?Sized> HeartbeatStreamExt for St where St: Stream {}
+
+#[pin_project]
+#[must_use = "streams do nothing unless polled"]
+#[derive(Debug)]
+/// Stream returned by [`heartbeat`](HeartbeatStreamExt::timeout).
+pub struct Heartbeat<S> {
+    #[pin]
+    stream: Fuse<S>,
+    #[pin]
+    deadline: Sleep,
+    interval: Duration,
+    needs_reset: bool,
+}
+
+impl<S: Stream> Heartbeat<S> {
+    pub fn new(stream: S, interval: Duration) -> Heartbeat<S> {
+        let stream = stream.fuse();
+        let next = Instant::now() + interval;
+        let deadline = tokio::time::sleep_until(next);
+
+        Heartbeat {
+            stream,
+            deadline,
+            interval,
+            needs_reset: true,
+        }
+    }
+}
+
+impl<S: Stream> Stream for Heartbeat<S> {
+    type Item = Result<S::Item, Beat>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        if *this.needs_reset {
+            let next = Instant::now() + *this.interval;
+            this.deadline.reset(next);
+            *this.needs_reset = false;
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        match this.stream.poll_next(cx) {
+            Poll::Ready(v) => {
+                if v.is_some() {
+                    *this.needs_reset = true;
+                }
+                return Poll::Ready(v.map(Ok));
+            }
+            Poll::Pending => {}
+        }
+
+        match this.deadline.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(_) => {
+                *this.needs_reset = true;
+                Poll::Ready(Some(Err(Beat::new())))
+            }
+        }
+    }
+}
+
+/// Error returned by `Heartbeat`.
+#[derive(Debug, PartialEq)]
+pub struct Beat(());
+
+impl Beat {
+    pub(crate) fn new() -> Self {
+        Beat(())
+    }
+}
+
+impl fmt::Display for Beat {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "heartbeat deadline has elapsed".fmt(fmt)
+    }
+}
+
+impl std::error::Error for Beat {}
+
+impl From<Beat> for std::io::Error {
+    fn from(_err: Beat) -> std::io::Error {
+        std::io::ErrorKind::TimedOut.into()
+    }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod application;
 pub mod chain_tracker;
 pub mod db;
+pub mod heartbeat;
 pub mod input;
 pub mod message_storage;
 pub mod message_stream;

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -188,6 +188,7 @@ where
             Some(node_pb::stream_messages_response::Message::Invalidate(invalidate)) => {
                 self.handle_invalidate(input_id, invalidate).await
             }
+            Some(node_pb::stream_messages_response::Message::Heartbeat(_)) => Ok(()),
         }
     }
 


### PR DESCRIPTION
This PR adds heartbeats to streams so that clients can check if the stream hang or it's still active.

The heartbeat interval is set at 30 seconds, but in the future it should be configurable.
