### PR TITLE
node: add sync feature to tokio-stream

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -28,7 +28,7 @@ prost = "0.11.0"
 prost-types = "0.11.1"
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["full"] }
-tokio-stream = "0.1.10"
+tokio-stream = { version = "0.1.10", features = ["sync"] }
 tokio-util = "0.7.4"
 tonic = { version = "0.8.2", features = ["tls", "tls-roots"] }
 tonic-health = "0.7.0"

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -28,7 +28,7 @@ prost-types = "0.11.1"
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "72702f6465a941bfb53692a1e40944aa797efa85" }
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["full"] }
-tokio-stream = { version = "0.1.9", features = ["sync"] }
+tokio-stream = { version = "0.1.10", features = ["sync"] }
 tokio-util = "0.7.3"
 tonic = "0.8.0"
 tonic-health = "0.7.0"


### PR DESCRIPTION
The crate uses `tokio_stream::wrappers::BroadcastStream` but didn't have
the `sync` feature.
Importing the crate in an external project would fail compiling because
of this.
