### PR TITLE
Add pending blocks support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
       if: matrix.check == 'clippy'
       run: cargo clippy
 
-    - name: cargo test
+    - name: cargo unit test
       if: matrix.check == 'test'
-      run: cargo test --all
+      run: cargo test --all --lib
 
   build_binaries:
     name: build ${{ matrix.binary }}, target=${{ matrix.job.target }}, os=${{ matrix.job.os }}

--- a/core/proto/node.proto
+++ b/core/proto/node.proto
@@ -70,6 +70,8 @@ message ConnectResponse {
 message StreamMessagesRequest {
   // Start streaming from the provided sequence number.
   uint64 starting_sequence = 1;
+  // Include pending blocks.
+  bool include_pending = 2;
 }
 
 // Message sent from the node to the client.
@@ -78,6 +80,7 @@ message StreamMessagesResponse {
     Invalidate invalidate = 1;
     Data data = 2;
     Heartbeat heartbeat = 3;
+    Data pending = 4;
   }
 }
 

--- a/core/proto/node.proto
+++ b/core/proto/node.proto
@@ -70,8 +70,8 @@ message ConnectResponse {
 message StreamMessagesRequest {
   // Start streaming from the provided sequence number.
   uint64 starting_sequence = 1;
-  // Include pending blocks.
-  bool include_pending = 2;
+  // If greater than 0, send pending blocks at the specified interval.
+  uint32 pending_block_interval_seconds = 2;
 }
 
 // Message sent from the node to the client.

--- a/core/src/stream.rs
+++ b/core/src/stream.rs
@@ -120,6 +120,10 @@ pub enum StreamMessage<D: MessageData> {
         sequence: Sequence,
         data: RawMessageData<D>,
     },
+    Pending {
+        sequence: Sequence,
+        data: RawMessageData<D>,
+    },
 }
 
 impl<D> StreamMessage<D>
@@ -136,11 +140,17 @@ where
         Self::Data { sequence, data }
     }
 
+    /// Creates a new `Pending` message.
+    pub fn new_pending(sequence: Sequence, data: RawMessageData<D>) -> Self {
+        Self::Pending { sequence, data }
+    }
+
     /// Returns the sequence number associated with the message.
     pub fn sequence(&self) -> &Sequence {
         match self {
             Self::Invalidate { sequence } => sequence,
             Self::Data { sequence, .. } => sequence,
+            Self::Pending { sequence, .. } => sequence,
         }
     }
 
@@ -152,6 +162,11 @@ where
     /// Returns true if it's an invalidate message.
     pub fn is_invalidate(&self) -> bool {
         matches!(self, Self::Invalidate { .. })
+    }
+
+    /// Returns true if it's a pending message.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending { .. })
     }
 }
 

--- a/node/src/input.rs
+++ b/node/src/input.rs
@@ -41,7 +41,7 @@ impl InputMixer {
             let mut client = NodeClient::connect(url).await?;
             let stream_request = node_pb::StreamMessagesRequest {
                 starting_sequence: input_config.starting_sequence,
-                include_pending: false,
+                pending_block_interval_seconds: 0,
             };
             let client_stream = client.stream_messages(stream_request).await?.into_inner();
             inner.insert(input_config.id, client_stream);

--- a/node/src/input.rs
+++ b/node/src/input.rs
@@ -41,6 +41,7 @@ impl InputMixer {
             let mut client = NodeClient::connect(url).await?;
             let stream_request = node_pb::StreamMessagesRequest {
                 starting_sequence: input_config.starting_sequence,
+                include_pending: false,
             };
             let client_stream = client.stream_messages(stream_request).await?.into_inner();
             inner.insert(input_config.id, client_stream);

--- a/node/src/message_stream.rs
+++ b/node/src/message_stream.rs
@@ -200,6 +200,12 @@ where
                         this.state.add_live_message(sequence, data);
                     }
                 }
+                Ok(StreamMessage::Pending { sequence, data }) => {
+                    if sequence == current {
+                        let message = StreamMessage::Pending { sequence, data };
+                        return Poll::Ready(Some(Ok(message)));
+                    }
+                }
             }
         }
 

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -202,6 +202,7 @@ where
                 self.handle_invalidate(input_id, invalidate).await
             }
             Some(node_pb::stream_messages_response::Message::Heartbeat(_)) => Ok(()),
+            Some(node_pb::stream_messages_response::Message::Pending(_)) => Ok(()),
         }
     }
 

--- a/node/src/processor.rs
+++ b/node/src/processor.rs
@@ -40,6 +40,7 @@ pub trait MessageProducer: Send + Sync + 'static {
     fn stream_from_sequence(
         &self,
         starting_sequence: &Sequence,
+        pending_interval: Option<Duration>,
         ct: CancellationToken,
     ) -> std::result::Result<Self::Stream, Self::Error>;
 }
@@ -264,6 +265,7 @@ where
     fn stream_from_sequence(
         &self,
         starting_sequence: &Sequence,
+        pending_interval: Option<Duration>,
         ct: CancellationToken,
     ) -> std::result::Result<Self::Stream, Self::Error> {
         info!(start = ?starting_sequence, "start stream");
@@ -279,6 +281,7 @@ where
             latest,
             self.storage.clone(),
             live,
+            pending_interval,
             ct,
         );
         Ok(stream)

--- a/node/src/server.rs
+++ b/node/src/server.rs
@@ -186,6 +186,20 @@ where
                         message: Some(node_pb::stream_messages_response::Message::Data(data)),
                     })
                 }
+                Ok(StreamMessage::Pending { sequence, data }) => {
+                    let inner_data = prost_types::Any {
+                        type_url: type_url.clone(),
+                        value: data.as_bytes().to_vec(),
+                    };
+                    let pending = node_pb::Data {
+                        sequence: sequence.as_u64(),
+                        data: Some(inner_data),
+                    };
+
+                    Ok(node_pb::StreamMessagesResponse {
+                        message: Some(node_pb::stream_messages_response::Message::Pending(pending)),
+                    })
+                }
             }
         }));
 

--- a/starknet/README.md
+++ b/starknet/README.md
@@ -13,3 +13,24 @@ docker run --rm -p 4317:4317 otel/opentelemetry-collector-dev:latest
 ```
 
 The docker container will periodically output the metric and trace data.
+
+## Testing
+
+You can run unit tests with:
+
+```
+cargo test -p apibara-starknet --lib
+```
+
+The project uses `starknet-devnet` for integration tests.
+Start the devnet container with:
+
+```
+docker run --rm -p 5050:5050 shardlabs/starknet-devnet:40d5b6f75fd80e5adea989e5f45ebb76c5c25cde-seed0
+```
+
+Then you can run integration tests on it.
+
+```
+cargo test -p apibara-starknet test_starknet_integration
+```

--- a/starknet/src/block_ingestion.rs
+++ b/starknet/src/block_ingestion.rs
@@ -89,6 +89,7 @@ where
     pub fn stream_from_sequence(
         &self,
         starting_sequence: u64,
+        pending_interval: Option<Duration>,
         ct: CancellationToken,
     ) -> Result<impl Stream<Item = message_stream::Result<StreamMessage<Block>>>> {
         info!(start = %starting_sequence, "start stream");
@@ -106,6 +107,7 @@ where
             latest,
             self.chain.clone(),
             live,
+            pending_interval,
             ct,
         ))
     }

--- a/starknet/src/server.rs
+++ b/starknet/src/server.rs
@@ -139,6 +139,26 @@ where
                                 message: Some(pb::stream_messages_response::Message::Data(data)),
                             })
                         }
+                        Ok(Ok(BlockStreamMessage::Pending {
+                            data: block,
+                            sequence,
+                        })) => {
+                            let inner_data = prost_types::Any {
+                                type_url: "type.googleapis.com/apibara.starknet.v1alpha1.Block"
+                                    .to_string(),
+                                value: block.as_bytes().to_vec(),
+                            };
+                            let pending = pb::Data {
+                                sequence: sequence.as_u64(),
+                                data: Some(inner_data),
+                            };
+
+                            Ok(pb::StreamMessagesResponse {
+                                message: Some(pb::stream_messages_response::Message::Pending(
+                                    pending,
+                                )),
+                            })
+                        }
                     }),
             );
 

--- a/starknet/tests/integration_test.rs
+++ b/starknet/tests/integration_test.rs
@@ -1,0 +1,98 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use apibara_starknet::{start_starknet_source_node, SequencerGateway};
+use starknet::{
+    accounts::{Account, Call, SingleOwnerAccount},
+    core::{chain_id, types::FieldElement, utils::get_selector_from_name},
+    providers::{Provider, SequencerGatewayProvider},
+    signers::{LocalWallet, SigningKey},
+};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+#[tokio::test]
+async fn test_starknet_integration() -> Result<()> {
+    let starknet_provider = new_devnet_client()?;
+    seed_devnet_transactions(&starknet_provider).await?;
+
+    let datadir = tempfile::tempdir()?;
+    let sequencer_gateway =
+        SequencerGateway::from_custom_str("http://localhost:5050/feeder_gateway")?;
+
+    let cts = CancellationToken::new();
+
+    tokio::spawn({
+        let ct = cts.clone();
+        async move {
+            start_starknet_source_node(
+                datadir.into_path(),
+                sequencer_gateway,
+                Duration::from_millis(200),
+                ct.clone(),
+            )
+            .await
+            .unwrap();
+        }
+    });
+
+    // TODO: stream data from node with local client
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    cts.cancel();
+    Ok(())
+}
+
+fn new_devnet_client() -> Result<SequencerGatewayProvider> {
+    let base_url = "http://localhost:5050".to_string();
+    let gateway_url: Url = format!("{}/gateway", base_url).parse()?;
+    let feeder_gateway_url: Url = format!("{}/feeder_gateway", base_url).parse()?;
+    let provider = SequencerGatewayProvider::new(gateway_url, feeder_gateway_url);
+    Ok(provider)
+}
+
+async fn seed_devnet_transactions(provider: &SequencerGatewayProvider) -> Result<()> {
+    // Account-0 in starknet-devnet
+    let secret_key = FieldElement::from_hex_be("0xe3e70682c2094cac629f6fbed82c07cd")
+        .context("parse secret key")?;
+    let address = FieldElement::from_hex_be(
+        "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
+    )
+    .context("parse address")?;
+
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(secret_key));
+    let account = SingleOwnerAccount::new(provider, signer, address, chain_id::TESTNET);
+
+    let eth_address = FieldElement::from_hex_be(
+        "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488",
+    )
+    .context("parse eth address")?;
+
+    let receiver_address = FieldElement::from_hex_be(
+        "0x69b49c2cc8b16e80e86bfc5b0614a59aa8c9b601569c7b80dde04d3f3151b79",
+    )
+    .context("parse receiver address")?;
+
+    // send a bunch of transactions
+    for _ in 0..20 {
+        account
+            .execute(&[Call {
+                to: eth_address,
+                selector: get_selector_from_name("transfer").unwrap(),
+                calldata: vec![
+                    receiver_address,
+                    FieldElement::from_dec_str("100000000000000000").unwrap(),
+                    FieldElement::ZERO,
+                ],
+            }])
+            .send()
+            .await?;
+    }
+
+    // get block number, check that devnet created some
+    let block = provider
+        .get_block(starknet::core::types::BlockId::Latest)
+        .await?;
+    assert!(block.block_number.unwrap() > 0);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for requesting pending blocks to be included.

This is useful to mainnet projects, where blocks are produced very infrequently.
