### PR TITLE
starknet: add weak header filter

### DIFF
--- a/starknet/proto/v1alpha2/filter.proto
+++ b/starknet/proto/v1alpha2/filter.proto
@@ -19,10 +19,9 @@ message Filter {
 }
 
 // Filter header.
-//
-// This filter matches _all_ headers, so it's only necessary
-// to include it in the filter to receive header data.
 message HeaderFilter {
+  // If true, only include headers if any other filter matches.
+  bool weak = 1;
 }
 
 // Filter transactions.

--- a/starknet/src/stream/block.rs
+++ b/starknet/src/stream/block.rs
@@ -40,6 +40,11 @@ where
         Ok(status)
     }
 
+    fn has_weak_header(&self) -> bool {
+        // No header is the same as a weak header.
+        self.filter.header.as_ref().map(|h| h.weak).unwrap_or(true)
+    }
+
     fn header(&self, block_id: &GlobalBlockId) -> Result<Option<v1alpha2::BlockHeader>, R::Error> {
         if self.filter.header.is_some() {
             self.storage.read_header(block_id)
@@ -282,7 +287,9 @@ where
         let status = self.status(block_id)?;
 
         let header = self.header(block_id)?;
-        has_data |= header.is_some();
+        if !self.has_weak_header() {
+            has_data |= header.is_some();
+        }
 
         let transactions = self.transactions(block_id)?;
         has_data |= !transactions.is_empty();


### PR DESCRIPTION
Most users need header information only if any other data matches.
This change introduces the concept of "weak" header: the header
is included only if any other filter matches.
