### PR TITLE
starknet: reject block from canonical chain

### DIFF
--- a/starknet/src/ingestion/accepted.rs
+++ b/starknet/src/ingestion/accepted.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    core::{pb::starknet::v1alpha2::BlockStatus, GlobalBlockId},
+    core::GlobalBlockId,
     db::{DatabaseStorage, StorageReader, StorageWriter},
     provider::{BlockId, Provider, ProviderError},
 };
@@ -399,8 +399,7 @@ where
                 break;
             }
 
-            txn.shrink_canonical_chain(&ingested_tip)?;
-            txn.write_status(&ingested_tip, BlockStatus::Rejected)?;
+            txn.reject_block_from_canonical_chain(&ingested_tip)?;
 
             // header must exist in the database
             let header = self

--- a/starknet/src/ingestion/started.rs
+++ b/starknet/src/ingestion/started.rs
@@ -69,7 +69,7 @@ where
                     "block was rejected while offline"
                 );
                 let mut txn = self.storage.begin_txn()?;
-                txn.shrink_canonical_chain(&latest_indexed)?;
+                txn.reject_block_from_canonical_chain(&latest_indexed)?;
                 txn.commit()?;
             } else if status.is_accepted() {
                 return self


### PR DESCRIPTION
Removing a block from the canonical chain implies changing the
status to rejected. The trait method now does that automatically.
