### PR TITLE
chore(starknet): match anyhow version with cairos package

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "=1.0.59"
+anyhow = "1.0.66"
 prost = "0.11.0"
 prost-types = "0.11.1"
 thiserror = "1.0.32"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ name = "apibara_node"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "=1.0.59"
+anyhow = "1.0.66"
 apibara-core = { path = "../core" }
 arrayvec = "0.7.2"
 async-trait = "0.1.57"

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -12,7 +12,7 @@ name = "apibara-starknet"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow = "=1.0.59"
+anyhow = "1.0.66"
 apibara-core = { path = "../core" }
 apibara-node = { path = "../node" }
 backoff = { version = "0.4.0", features = ["tokio"] }


### PR DESCRIPTION
Update anyhow version to match the one used in the cairo repo https://github.com/starkware-libs/cairo/blob/5368d3147921ec3e34c59c84666978ada1979580/Cargo.toml#L41