### PR TITLE
starknet: stream data from chain without finalized blocks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/starknet/src/stream/filtered.rs
+++ b/starknet/src/stream/filtered.rs
@@ -101,10 +101,16 @@ where
                 .map_err(StreamError::internal)?;
             // stream needs at least a finalized or accepted block.
             match (finalized_cursor, accepted_cursor) {
-                (Some(finalized_cursor), Some(accepted_cursor)) => (Some(finalized_cursor), accepted_cursor),
+                (Some(finalized_cursor), Some(accepted_cursor)) => {
+                    (Some(finalized_cursor), accepted_cursor)
+                }
                 (None, Some(accepted_cursor)) => (None, accepted_cursor),
                 (Some(finalized_cursor), None) => (Some(finalized_cursor), finalized_cursor),
-                (None, None) => return Err(StreamError::internal(FilteredDataStreamError::NoFinalizedBlockIngested)),
+                (None, None) => {
+                    return Err(StreamError::internal(
+                        FilteredDataStreamError::NoFinalizedBlockIngested,
+                    ))
+                }
             }
         };
 


### PR DESCRIPTION
This PR improves compatibility with starknet-devnet.

Devnet doesn't produce finalized blocks and so we need to handle
this case by sending accepted blocks.
