### PR TITLE
starknet: pause ingestion on error

### DIFF
--- a/starknet/src/ingestion/config.rs
+++ b/starknet/src/ingestion/config.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 
 /// Block ingestion configuration.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockIngestionConfig {
     /// Concurrency for RPC requests.
     pub rpc_concurrency: usize,

--- a/starknet/src/ingestion/subscription.rs
+++ b/starknet/src/ingestion/subscription.rs
@@ -10,9 +10,10 @@ use super::error::BlockIngestionError;
 
 pub type IngestionStream = BroadcastStream<IngestionMessage>;
 
+#[derive(Clone)]
 pub struct IngestionStreamPublisher {
     tx: Arc<broadcast::Sender<IngestionMessage>>,
-    _rx: broadcast::Receiver<IngestionMessage>,
+    _rx: Arc<broadcast::Receiver<IngestionMessage>>,
 }
 
 pub struct IngestionStreamClient {
@@ -23,6 +24,7 @@ impl IngestionStreamPublisher {
     pub fn new() -> (IngestionStreamClient, IngestionStreamPublisher) {
         let (tx, rx) = broadcast::channel(128);
         let tx = Arc::new(tx);
+        let rx = Arc::new(rx);
 
         let manager = IngestionStreamPublisher {
             tx: tx.clone(),


### PR DESCRIPTION
Change the ingestion code to simply pause ingestion when it encounters
an error. This means that users can keep streaming data even if there is
a network/node outage.
